### PR TITLE
Adding archive notice to top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> **This repository has been archived as of 2026-01-12.** The functionality has been migrated to the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) as the [`ww-saturation` pipeline](https://github.com/getwilds/wilds-wdl-library/tree/main/pipelines/ww-saturation). Please refer to that instance for the latest versions, documentation, and updates.
+
 # ww-saturation: Saturation Mutagenesis Workflow
 
 ## Overview


### PR DESCRIPTION
## Description
- With the expansion of the WILDS WDL Library, this pipeline has been migrated to the library accordingly and this standalone repo is no longer needed. To preserve contributions, we will archive the repo rather than delete it, but redirect folks to the WILDS WDL Library via a blurb at the top of the README.
- Tagging @sitapriyamoorthi and @sobrien29 for visibility. Thank you both for your efforts on this!